### PR TITLE
added missing replacement for component.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -71,6 +71,7 @@ gulp.task('babel', ['assets'], function() {
     `${BASE}component.js`
   ])
     .pipe(replace('const LAYOUT;', `const LAYOUT = "${ hbs }";`))
+    .pipe(replace(NAME_TOKEN, DRIVER_NAME)) 
     .pipe(babel(opts))
     .pipe(gulpConcat(`component.js`,{newLine: ';\n'}))
     .pipe(gulp.dest(TMP));


### PR DESCRIPTION
This pull request contains a fix for the `gulpfile.js`. The token (placeholder of the driver) was replaced in e.g. the `component.css` and `rexport.js`. But it was missing in the `component.js`. With this change, the skeleton now works again.